### PR TITLE
[Server] / #87 / fix add empty array

### DIFF
--- a/server/src/routes/routes.service.ts
+++ b/server/src/routes/routes.service.ts
@@ -788,7 +788,6 @@ export class RoutesService {
             'Pins.ward',
             'Pictures.fileName',
           ])
-          .whereInIds(routeIds)
           .where(
             'Routes.public = 1 AND Routes.time = :time AND Routes.id IN (:routeIds)',
             {


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
feature/87-addSearching -> dev

### 변경 사항
- WHERE IN 구문에서 빈 배열을 사용할 시  구문 오류가 나는 것 해결

### 테스트 결과
정상 작동합니다.

close #87 