### PR TITLE
[Client] / hotfix / fix search routes

### DIFF
--- a/client/src/components/searchRoutesBar/searchRoutesBar.tsx
+++ b/client/src/components/searchRoutesBar/searchRoutesBar.tsx
@@ -4,7 +4,7 @@ import { Route } from './../../types/searchRoutesTypes';
 import axios from 'axios';
 
 type Props = {
-  setSearchResult: React.Dispatch<React.SetStateAction<Route[]>>;
+  setSearchResult: React.Dispatch<React.SetStateAction<Route[] | null>>;
   setRouteCount: React.Dispatch<React.SetStateAction<number>>;
   setSearchQuery: React.Dispatch<
     React.SetStateAction<{
@@ -74,7 +74,6 @@ function SearchRoutesBar({
   const postSearch = () => {
     if (searchBarText === '') return alert('검색어를 입력해 주세요!');
 
-    const controller = new AbortController();
     axios
       .get(
         `https://server.memory-road.net/routes?search=true&${getQueryStr(
@@ -82,7 +81,6 @@ function SearchRoutesBar({
           routeorLocation,
           searchBarText,
         )}`,
-        { signal: controller.signal },
       )
       .then((result) => {
         setRouteCount(result.data.count);
@@ -95,17 +93,12 @@ function SearchRoutesBar({
         });
         setIsSidebarOpen(true);
         setSelectedRoute(null);
+
+        if (result.data.count === 0) return alert('검색결과가 없습니다.');
       })
       .catch((err) => {
-        //abort 에러는 경고창에 표시하지 않는다
-        if (err.name === 'AbortError') {
-          throw 'AbortError';
-        }
+        throw err;
       });
-
-    //응답을 받기 전에 요청이 가면 이전 요청을 취소한다
-    //https://axios-http.com/docs/cancellation
-    controller.abort();
   };
 
   useEffect(() => {

--- a/client/src/components/searchSideBar/searchSideBar.tsx
+++ b/client/src/components/searchSideBar/searchSideBar.tsx
@@ -9,14 +9,14 @@ import SeoulSelectBox from '../seoulSelectBox/seoulSelectBoxForMap';
 import TimeSelectBox from '../timeSelectBox/timeSelectBox';
 
 type Props = {
-  searchResult: Route[];
+  searchResult: Route[] | null;
   routeCount: number;
   isSidebarOpen: boolean;
   setIsSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedRoute: React.Dispatch<React.SetStateAction<Route | null>>;
   selectedRoute: Route | null;
   setRouteCount: React.Dispatch<React.SetStateAction<number>>;
-  setSearchResult: React.Dispatch<React.SetStateAction<Route[]>>;
+  setSearchResult: React.Dispatch<React.SetStateAction<Route[] | null>>;
   setSearchQuery: React.Dispatch<
     React.SetStateAction<{
       rq?: string | undefined;
@@ -100,6 +100,19 @@ function SearchSideBar({
     }
   }, [searchQuery]);
 
+  //검색 결과에 따라 카드 랜더링
+  function renderCards(searchResult: Route[] | null) {
+    if (searchResult === null) return null;
+    return searchResult.map((routeInfo: Route) => (
+      <StoryCard
+        key={routeInfo.id}
+        routeInfo={routeInfo}
+        selectedRoute={selectedRoute}
+        setSelectedRoute={setSelectedRoute}
+      />
+    ));
+  }
+
   return (
     <>
       <div id="pinControllTower-fix-search">
@@ -133,14 +146,7 @@ function SearchSideBar({
                 </div>
               </div>
               <div className="pinControllTower-content-search">
-                {searchResult.map((routeInfo) => (
-                  <StoryCard
-                    key={routeInfo.id}
-                    routeInfo={routeInfo}
-                    selectedRoute={selectedRoute}
-                    setSelectedRoute={setSelectedRoute}
-                  />
-                ))}
+                {renderCards(searchResult)}
                 {routeCount > 5 ? (
                   <div className="pagination-button">
                     <Pagination

--- a/client/src/pages/searchRoutes/searchRoutes.tsx
+++ b/client/src/pages/searchRoutes/searchRoutes.tsx
@@ -33,8 +33,8 @@ function SearchRoutes() {
   //state들
   //지도의 확대 정도
   const [currLevel, setCurrLevel] = useState(9);
-  //검색 버튼을 눌러 가져온 루트의 정보들--->이게 없으면 범주화 기능
-  const [searchResult, setSearchResult] = useState<Route[]>([]);
+  //검색 버튼을 눌러 가져온 루트의 정보들. null인 경우, 현재 보고있는 화면을 기준으로 루트들을 검색한다.
+  const [searchResult, setSearchResult] = useState<Route[] | null>(null);
   //총 루트의 개수. 페이지네이션에 사용
   const [routeCount, setRouteCount] = useState<number>(0);
   //검색 요청을 보낼 때 사용하는 쿼리 객체
@@ -333,8 +333,8 @@ function SearchRoutes() {
   useEffect(() => {
     if (kakaoMap === null) return;
 
-    if (searchResult.length !== 0) {
-      //검색 결과가 있는 경우, 폴리곤을 없애고 검색 결과들을 보여준다.
+    if (searchResult !== null) {
+      //검색버튼을 누련 경우(검색 결과가 없어도 배열이 state가 된다.), 폴리곤을 없애고 검색 결과들을 보여준다.
 
       //폴리곤 삭제
       wardPolygons.forEach((promise) => {
@@ -398,7 +398,7 @@ function SearchRoutes() {
   // //검색 결과가 없으면서(검색 버튼을 누르지 않은 경우), 지도가 일정 레벨 이하이면, 꼭지점의 위도, 경도를 이용해 루트들을 조회한다.
   useEffect(() => {
     if (kakaoMap === null) return;
-    if (searchResult.length === 0 && currLevel <= 6) {
+    if (searchResult === null && currLevel <= 6) {
       //폴리곤 삭제
       wardPolygons.forEach((promise) => {
         promise.then((pol) => pol.setMap(null));
@@ -483,7 +483,7 @@ function SearchRoutes() {
       //응답을 받기 전에 요청이 가면 이전 요청을 취소한다
       //https://axios-http.com/docs/cancellation
       controller.abort();
-    } else if (searchResult.length === 0) {
+    } else if (searchResult === null) {
       //검색 결과가 없으면서 지도 레벨이 높아진 경우
 
       //기존 핀의 인포윈도우 제거


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
hotfix/searchRoute -> dev

### 변경 사항
- 없는 루트를 검색했을 경우, 기존 상태가 사라지지 않고, 검색하기 않은 루트가 보이는 현상 수정
- abortcontroll가 검색 기능에서 상태를 수정시키지 못하는 문제가 있어서 제거

### 테스트 결과
정상 동작합니다.