### PR TITLE
[Server] / hotfix: log out bug fix

### DIFF
--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -246,11 +246,17 @@ export class UsersController {
   // 로그 아웃
   @Get('/auth')
   async logOut(@Res() res: Response, @Req() req: Request) {
-    if (!req.cookies || !req.cookies.accessToken) {
-      return res.status(401).json({ error: '쿠키 재요청이 필요합니다' });
-    }
-    const accessToken = req.cookies.accessToken;
-    await this.usersService.logOut(accessToken);
+    // 쿠키 검증을 할 거였으면, 쿠키 만료 시간에 맞춰 로그아웃 시키는 로직을 만들던가 했어야했다
+    // 클라이언트와 상의해서 저런 로직을 만들었다면 쿠키에 정보가 살아 있으니 상관 없었을텐데
+    // 지금은 쿠키 만료 시간 이후에 로그 아웃을 보내면 단순히 로그아웃이 안 되는 이상한 사이트가
+    // 되어버림
+    // 나중에 조금 더 추가적으로 로직 생각을 해봐야 할 것 같다
+
+    // if (!req.cookies || !req.cookies.accessToken) {
+    //   return res.status(401).json({ error: '쿠키 재요청이 필요합니다' });
+    // }
+    // const accessToken = req.cookies.accessToken;
+    // await this.usersService.logOut(accessToken);
     //아무것도 없는 쿠키 전달
     res.cookie('accessToken', 'success', {
       httpOnly: true,

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -222,10 +222,10 @@ export class UsersService {
   }
 
   //로그아웃, 하는 건 없는데, 로그아웃 이후의 이벤트등을 추가할 경우에 사용할 수 있을 것 같아 남겨둠
-  async logOut(accessToken: string): Promise<string | jwt.JwtPayload> {
-    const decoded = await this.verifyAccessToken(accessToken);
-    return decoded;
-  }
+  // async logOut(accessToken: string): Promise<string | jwt.JwtPayload> {
+  //   const decoded = await this.verifyAccessToken(accessToken);
+  //   return decoded;
+  // }
 
   //회원 정보 업데이트 프로필이미지
   async updateProfile(accessToken: string, file: Express.Multer.File) {


### PR DESCRIPTION
### PR 타입
- [x] 기능 삭제
- [x] 버그 수정

### 반영 브랜치
 hotfix/logOutBugFix -> dev

### 변경 사항
로그아웃시 쿠키에 담긴 토큰 검증하는 방식의 로직을 삭제시켰습니다.
그로 인해  [로그인 후 5시간이 지나 쿠키가 만료되면 로그 아웃이 되지 않던 버그]가 수정되었습니다.

### 테스트 결과
정상 작동함을 확인할 수 있었습니다.
